### PR TITLE
Fix the badge links and add your name to the Licence

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2018 Varun Nayyar
+Copyright (c) 2019 Michael Lyons
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Crontab for Sublime Text 3
 
-[![GitHub license](https://img.shields.io/github/license/nayyarv/CrontabSublime.svg)](https://github.com/nayyarv/CrontabSublime/blob/master/LICENSE) [![GitHub release](https://img.shields.io/github/release/nayyarv/CrontabSublime.svg)](https://GitHub.com/nayyarv/CrontabSublime/releases/) [![Package Control](https://packagecontrol.herokuapp.com/downloads/Crontab.svg?style=flat-square)](https://packagecontrol.io/packages/Crontab)
+[![GitHub license](https://img.shields.io/github/license/michaelblyons/CrontabSublime.svg)](https://github.com/michaelblyons/CrontabSublime/blob/master/LICENSE) [![GitHub release](https://img.shields.io/github/release/michaelblyons/CrontabSublime.svg)](https://GitHub.com/michaelblyons/CrontabSublime/releases/) [![Package Control](https://packagecontrol.herokuapp.com/downloads/Crontab.svg?style=flat-square)](https://packagecontrol.io/packages/Crontab)
 
 ![Example screenshot][screenshot]
 


### PR DESCRIPTION
Firstly, the badge links were pointing to my namespace so they weren't working super well anymore. This should take care of that. You might want to do a 1.0.1 release so that https://packagecontrol.io/packages/Crontab.io looks better!

Additionally, I've added you the MIT Licence as an author too. I think this is the correct thing to do, especially since the package is now under your namespace.